### PR TITLE
feat(ci): Add markdown linter and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,31 @@
 name: ci
 on:
   push:
+    branches: [main]
     tags:
       - v*
+  pull_request:
+    branches: [main]
 permissions:
   contents: write
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Lint markdown files
+        run: npm run lint
+  
   deploy:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,23 @@
+config:
+  # MD013/line-length - Allow longer lines for documentation
+  MD013:
+    line_length: 120
+    code_blocks: false
+    tables: false
+    headings: false
+  
+  # MD033/no-inline-html - Allow inline HTML for MkDocs extensions
+  MD033: false
+  
+  # MD041/first-line-heading - Don't require first line to be heading
+  MD041: false
+  
+  # MD024/no-duplicate-heading - Allow duplicate headings (common in docs)
+  MD024:
+    siblings_only: true
+
+globs:
+  - "docs/**/*.md"
+  - "*.md"
+  - "!site/**"
+  - "!.git/**"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: help lint lint-fix serve build install-deps clean
+
+# Default target
+help:
+	@echo "Available commands:"
+	@echo "  make install-deps  Install project dependencies"
+	@echo "  make lint          Run markdown linter"
+	@echo "  make lint-fix      Run markdown linter and fix issues"
+	@echo "  make serve         Serve documentation locally"
+	@echo "  make build         Build documentation"
+	@echo "  make clean         Clean build artifacts"
+
+# Install dependencies
+install-deps:
+	@echo "Installing Python dependencies..."
+	pip install -r requirements.txt
+	@echo "Installing Node.js dependencies..."
+	npm install
+
+# Lint markdown files
+lint:
+	@echo "Linting markdown files..."
+	npm run lint
+
+# Lint and fix markdown files
+lint-fix:
+	@echo "Linting and fixing markdown files..."
+	npm run lint:fix
+
+# Serve documentation locally
+serve:
+	@echo "Starting local development server..."
+	mkdocs serve
+
+# Build documentation
+build:
+	@echo "Building documentation..."
+	mkdocs build
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf site/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# Arda Documentation
+
+This repository contains the documentation for the Arda project, built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+
+## Quick Start
+
+1. **Install dependencies:**
+   ```bash
+   make install-deps
+   ```
+
+2. **Serve locally:**
+   ```bash
+   make serve
+   ```
+
+3. **Build documentation:**
+   ```bash
+   make build
+   ```
+
+## Available Commands
+
+- `make help` - Show available commands
+- `make install-deps` - Install project dependencies
+- `make lint` - Run markdown linter
+- `make lint-fix` - Run markdown linter and fix issues automatically
+- `make serve` - Serve documentation locally at http://127.0.0.1:8000
+- `make build` - Build documentation to `site/` directory
+- `make clean` - Clean build artifacts
+
+## Linting
+
+This project uses [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) to ensure consistent markdown formatting. The linting rules are configured in `.markdownlint-cli2.yaml`.
+
+### Running Linting
+
+```bash
+# Check for linting issues
+make lint
+
+# Automatically fix linting issues where possible
+make lint-fix
+```
+
+### Linting Rules
+
+The project uses a customized set of rules appropriate for documentation:
+
+- Line length limit: 120 characters (excluding code blocks, tables, and headings)
+- Inline HTML is allowed (for MkDocs extensions)
+- First line doesn't need to be a heading
+- Duplicate headings are allowed if they're in different sections
+
+## CI/CD
+
+The project includes GitHub Actions workflows that:
+
+- **Lint markdown files** on every pull request and push to main
+- **Deploy documentation** to GitHub Pages when a new tag is pushed
+
+## Development
+
+### Prerequisites
+
+- Python 3.x
+- Node.js 18+
+- npm
+
+### Local Development
+
+1. Clone the repository
+2. Run `make install-deps` to install dependencies
+3. Run `make serve` to start the development server
+4. Edit markdown files in the `docs/` directory
+5. Run `make lint` to check your changes
+
+The development server will automatically reload when you make changes to the documentation files.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "arda-docs",
+  "version": "1.0.0",
+  "description": "Arda documentation site",
+  "private": true,
+  "scripts": {
+    "lint": "markdownlint-cli2 \"docs/**/*.md\" \"*.md\"",
+    "lint:fix": "markdownlint-cli2 --fix \"docs/**/*.md\" \"*.md\""
+  },
+  "devDependencies": {
+    "markdownlint-cli2": "^0.13.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.0.0


### PR DESCRIPTION
Add markdown linting with a Makefile and CI integration to ensure consistent documentation formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive project documentation and usage instructions.
  - Introduced a Makefile with common commands for installation, linting, serving, building, and cleaning.
  - Added configuration for markdown linting with customized rules.
  - Set up a package manager configuration for linting scripts and dependencies.

- **Chores**
  - Established automated CI workflows for linting and deployment.
  - Added project dependencies for documentation and linting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->